### PR TITLE
Do not assert static library paths

### DIFF
--- a/libgssapi-sys/build.rs
+++ b/libgssapi-sys/build.rs
@@ -37,7 +37,7 @@ fn which() -> Gssapi {
 
         let krb5_path = krb5_path.as_ref().map(|s| s.trim());
 
-        for path in ldpath.split(':').chain(paths).chain(krb5_path) {
+        for path in krb5_path.into_iter().chain(ldpath.split(':')).chain(paths) {
             if search_pat(path, "libgssapi_krb5.so*") {
                 return Gssapi::Mit;
             }


### PR DESCRIPTION
In systems such as NixOS, we can't really assert static library paths. This patch adds an extra layer with `krb5-config`, so the build process is able to find the gssapi library, which in my case was in:

```
/nix/store/gi12qahl7d6h26sgj04mm89gimkanf6q-libkrb5-1.18/lib/libgssapi_krb5.so
```

When using `bindgen` in NixOS, we must set certain cflags. So, we'll check the environment for `NIX_CFLAGS_COMPILE`, and if set, add params to bindgen for proper compilation.

This has been tested with the following Nix flake:

```nix
{
  description = "Rust build tools";
  # Provides abstraction to boiler-code when specifying multi-platform outputs.
  inputs = {
    flake-utils.url = "github:numtide/flake-utils";
    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
    rust-overlay.url = "github:oxalica/rust-overlay";
  };

  outputs = { self, nixpkgs, flake-utils, rust-overlay, ... }:
    flake-utils.lib.eachDefaultSystem (system: let
      mkPkgs = pkgs: extraOverlays: import pkgs {
        inherit system;
        config.allowUnfree = true;
        overlays = extraOverlays;
      };

      pkgs = mkPkgs nixpkgs [ rust-overlay.overlay ];
    in {
      devShell = pkgs.mkShell {
        LIBCLANG_PATH="${pkgs.llvmPackages.libclang}/lib";
        nativeBuildInputs = with pkgs; [
          rust-bin.stable.latest.rust
          rust-bin.stable.latest.cargo

          llvmPackages.libclang
          clangStdenv
          kerberos
          glibc
        ];
      };
    });
}
```

We could of course commit the flake here too, if you want. It won't do anything for people not using Nix, but Nix users can say `nix develop` and can compile this package without any trouble.