### PR TITLE
Fix error message construction

### DIFF
--- a/libgssapi/src/error.rs
+++ b/libgssapi/src/error.rs
@@ -1,7 +1,7 @@
 use crate::util::Buf;
 use libgssapi_sys::{
     gss_OID_desc, gss_display_status, OM_uint32, GSS_C_CALLING_ERROR_OFFSET,
-    GSS_C_GSS_CODE, GSS_C_ROUTINE_ERROR_OFFSET, GSS_S_COMPLETE,
+    GSS_C_GSS_CODE, GSS_C_MECH_CODE, GSS_C_ROUTINE_ERROR_OFFSET, GSS_S_COMPLETE,
     _GSS_C_CALLING_ERROR_MASK, _GSS_C_ROUTINE_ERROR_MASK, _GSS_S_BAD_BINDINGS,
     _GSS_S_BAD_MECH, _GSS_S_BAD_MECH_ATTR, _GSS_S_BAD_MIC, _GSS_S_BAD_NAME,
     _GSS_S_BAD_NAMETYPE, _GSS_S_BAD_QOP, _GSS_S_BAD_SIG, _GSS_S_BAD_STATUS,
@@ -64,7 +64,7 @@ pub struct Error {
 }
 
 impl Error {
-    fn fmt_code(f: &mut fmt::Formatter<'_>, code: u32, name: &str) -> fmt::Result {
+    fn fmt_code(f: &mut fmt::Formatter<'_>, code: u32, ctype: u32) -> fmt::Result {
         let mut message_context: OM_uint32 = 0;
         loop {
             let mut minor = GSS_S_COMPLETE as OM_uint32;
@@ -73,18 +73,22 @@ impl Error {
                 gss_display_status(
                     &mut minor as *mut OM_uint32,
                     code,
-                    GSS_C_GSS_CODE as i32,
+                    ctype as i32,
                     ptr::null_mut::<gss_OID_desc>(),
                     &mut message_context as *mut OM_uint32,
                     buf.to_c(),
                 )
             };
-            if major == GSS_S_COMPLETE {
+            if major == GSS_S_COMPLETE || major == GSS_S_CONTINUE_NEEDED {
                 let s = String::from_utf8_lossy(&*buf);
-                let res = write!(f, "gssapi {} error {}\n", name, s);
+                let res = match ctype {
+                    GSS_C_GSS_CODE => write!(f, "{}", s),
+                    GSS_C_MECH_CODE => write!(f, " ({})", s),
+                    _ => panic!("invalid error message type: {}", ctype),
+                };
                 res?
             } else {
-                write!(f, "gssapi unknown {} error code {}\n", name, code)?;
+                write!(f, "unknown GSSAPI({}) error code({})\n", ctype, code)?;
                 break;
             }
             if message_context == 0 {
@@ -97,8 +101,8 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Error::fmt_code(f, self.major.bits(), "major")?;
-        Ok(Error::fmt_code(f, self.minor, "minor")?)
+        Error::fmt_code(f, self.major.bits(), GSS_C_GSS_CODE)?;
+        Ok(Error::fmt_code(f, self.minor, GSS_C_MECH_CODE)?)
     }
 }
 


### PR DESCRIPTION
When displaying error messages from GSSAPI calls (indirectly, via `cross-krb5`), I noticed that the returned error message string didn't really describe the error. For example, an expired ticket produced

```
gssapi major error Unspecified GSS failure.  Minor code may provide more information
gssapi minor error An invalid status code was supplied
gssapi minor error An invalid status code was supplied
gssapi minor error An invalid status code was supplied
gssapi minor error An invalid status code was supplied
gssapi minor error An invalid status code was supplied
gssapi minor error An invalid status code was supplied
gssapi minor error An invalid status code was supplied
```
Checking `gssapi/src/error.rs`, I saw that `gss_display_status()` is never called with the minor code _indication_ (it's called with the minor code _value_), so I made a couple of changes.

* The two calls into the formatter now pass `GSS_C_GSS_CODE` and
 `GSS_C_MECH_CODE` to `gss_display_status()`, so the minor (mechanism)
  message is actually placed in the message buffer.

* Following the recommendation in RFC 2743, `GSS_S_CONTINUE_NEEDED`
  is accepted and treated in the same way as `GSS_S_COMPLETE` if
  returned from `gss_display_status()`.

Message formatting is changed so that minor messages are placed
between parentheses and concatenated, not newline-separated.

After this, the "expired ticket" message looks like this:

```
Unspecified GSS failure.  Minor code may provide more information (Ticket expired)
```