### PR TITLE
add Name::display_name

### DIFF
--- a/libgssapi/src/name.rs
+++ b/libgssapi/src/name.rs
@@ -31,19 +31,12 @@ impl Drop for Name {
 
 impl fmt::Debug for Name {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let mut minor = GSS_S_COMPLETE;
-        let mut buf = Buf::empty();
-        let mut oid = ptr::null_mut::<gss_OID_desc>();
-        let major = unsafe {
-            gss_display_name(
-                &mut minor as *mut OM_uint32,
-                self.to_c(),
-                buf.to_c(),
-                &mut oid as *mut gss_OID,
-            )
-        };
-        if major == GSS_S_COMPLETE {
-            write!(f, "{}", String::from_utf8_lossy(&*buf))
+        if let Ok(buf) = self.display_name() {
+            if let Ok(s) = std::str::from_utf8(&buf) {
+                write!(f, "{}", s)
+            } else {
+                write!(f, "<name can't be decoded>")
+            }
         } else {
             write!(f, "<name can't be displayed>")
         }


### PR DESCRIPTION
This wraps [`gss_display_name`](https://docs.rs/libgssapi-sys/latest/libgssapi_sys/fn.gss_display_name.html) in a way that lets the user handle errors. It also lets the user do UTF-8 decoding themselves instead of automatically calling [`String::from_utf8_lossy`](https://doc.rust-lang.org/std/string/struct.String.html#method.from_utf8_lossy).