### PR TITLE
Upgrade dependencies

### DIFF
--- a/libgssapi-sys/Cargo.toml
+++ b/libgssapi-sys/Cargo.toml
@@ -14,4 +14,4 @@ categories = ["api-bindings", "authentication", "cryptography", "os::unix-apis"]
 links = "gssapi_krb5"
 
 [build-dependencies]
-bindgen = "0.59"
+bindgen = "0.64"

--- a/libgssapi/Cargo.toml
+++ b/libgssapi/Cargo.toml
@@ -20,5 +20,5 @@ localname = []
 [dependencies]
 bytes = "1"
 libgssapi-sys = { version = "0.2.4", path = "../libgssapi-sys" }
-bitflags = "1.3"
+bitflags = "2.0"
 lazy_static = "1.4"

--- a/libgssapi/src/credential.rs
+++ b/libgssapi/src/credential.rs
@@ -124,7 +124,7 @@ impl Cred {
             Ok(Cred(cred))
         } else {
             Err(Error {
-                major: unsafe { MajorFlags::from_bits_unchecked(major) },
+                major: MajorFlags::from_bits_retain(major),
                 minor
             })
         }
@@ -168,7 +168,7 @@ impl Cred {
             if let Some(s) = ifo.mechanisms {
                 OidSet::from_c(s);
             }
-            Err(Error { major: MajorFlags::from_bits_unchecked(major), minor })
+            Err(Error { major: MajorFlags::from_bits_retain(major), minor })
         } else {
             Ok(ifo)
         }

--- a/libgssapi/src/error.rs
+++ b/libgssapi/src/error.rs
@@ -15,6 +15,7 @@ use libgssapi_sys::{
 use std::{error, fmt, ptr, os::raw::c_int};
 
 bitflags! {
+    #[derive(Clone, Copy, Debug)]
     pub struct MajorFlags: u32 {
         // calling errors
         const GSS_S_CALL_INACCESSIBLE_READ = _GSS_S_CALL_INACCESSIBLE_READ;

--- a/libgssapi/src/name.rs
+++ b/libgssapi/src/name.rs
@@ -85,7 +85,7 @@ impl Name {
             Ok(Name(name))
         } else {
             Err(Error {
-                major: unsafe { MajorFlags::from_bits_unchecked(major) },
+                major: MajorFlags::from_bits_retain(major),
                 minor
             })
         }
@@ -112,7 +112,7 @@ impl Name {
             Ok(Name(out))
         } else {
             Err(Error {
-                major: unsafe { MajorFlags::from_bits_unchecked(major) },
+                major: MajorFlags::from_bits_retain(major),
                 minor
             })
         }
@@ -135,7 +135,7 @@ impl Name {
             Ok(out)
         } else {
             Err(Error {
-                major: unsafe { MajorFlags::from_bits_unchecked(major) },
+                major: MajorFlags::from_bits_retain(major),
                 minor
             })
         }
@@ -160,7 +160,7 @@ impl Name {
             Ok(out)
         } else {
             Err(Error {
-                major: unsafe { MajorFlags::from_bits_unchecked(major) },
+                major: MajorFlags::from_bits_retain(major),
                 minor
             })
         }
@@ -185,7 +185,7 @@ impl Name {
             Ok(out)
         } else {
             Err(Error {
-                major: unsafe { MajorFlags::from_bits_unchecked(major) },
+                major: MajorFlags::from_bits_retain(major),
                 minor
             })
         }
@@ -206,7 +206,7 @@ impl Name {
             Ok(Name(copy))
         } else {
             Err(Error {
-                major: unsafe { MajorFlags::from_bits_unchecked(major) },
+                major: MajorFlags::from_bits_retain(major),
                 minor
             })
         }

--- a/libgssapi/src/oid.rs
+++ b/libgssapi/src/oid.rs
@@ -296,7 +296,7 @@ impl OidSet {
             Ok(OidSet(out))
         } else {
             Err(Error {
-                major: unsafe { MajorFlags::from_bits_unchecked(major) },
+                major: MajorFlags::from_bits_retain(major),
                 minor,
             })
         }
@@ -330,7 +330,7 @@ impl OidSet {
             Ok(())
         } else {
             Err(Error {
-                major: unsafe { MajorFlags::from_bits_unchecked(major) },
+                major: MajorFlags::from_bits_retain(major),
                 minor,
             })
         }
@@ -353,7 +353,7 @@ impl OidSet {
             Ok(if present != 0 { true } else { false })
         } else {
             Err(Error {
-                major: unsafe { MajorFlags::from_bits_unchecked(major) },
+                major: MajorFlags::from_bits_retain(major),
                 minor,
             })
         }

--- a/libgssapi/src/util.rs
+++ b/libgssapi/src/util.rs
@@ -1,7 +1,7 @@
 use bytes;
 use libgssapi_sys::{
-    gss_buffer_desc, gss_buffer_desc_struct, gss_buffer_t, gss_release_buffer, size_t,
-    OM_uint32, GSS_S_COMPLETE,
+    gss_buffer_desc, gss_buffer_desc_struct, gss_buffer_t, gss_release_buffer, OM_uint32,
+    GSS_S_COMPLETE,
 };
 use std::{
     ffi,
@@ -131,7 +131,7 @@ mod iov {
             let gss_iov = gss_iov_buffer_desc {
                 type_: typ.to_c(),
                 buffer: gss_buffer_desc_struct {
-                    length: data.len() as size_t,
+                    length: data.len(),
                     value: data.as_mut_ptr().cast(),
                 },
             };
@@ -207,7 +207,7 @@ impl<'a> Deref for BufRef<'a> {
 impl<'a> From<&'a [u8]> for BufRef<'a> {
     fn from(s: &[u8]) -> Self {
         let gss_buf = gss_buffer_desc_struct {
-            length: s.len() as size_t,
+            length: s.len(),
             value: s.as_ptr() as *mut ffi::c_void,
         };
         BufRef(gss_buf, PhantomData)
@@ -261,7 +261,7 @@ impl Drop for Buf {
 impl Buf {
     pub(crate) fn empty() -> Buf {
         Buf(gss_buffer_desc {
-            length: 0 as size_t,
+            length: 0,
             value: ptr::null_mut(),
         })
     }


### PR DESCRIPTION
Everything is pretty straightforward except `bitflags` 's `from_bits_unchecked` function was renamed to `from_bits_retain` (and became safe) and bindgen defaults to `usize`  for `size_t` now.