### PR TITLE
allow passing GSS_C_NO_CREDENTIAL to gss_init_sec_context

### DIFF
--- a/libgssapi/src/credential.rs
+++ b/libgssapi/src/credential.rs
@@ -6,6 +6,8 @@ use libgssapi_sys::{
 };
 use std::{ptr, fmt, time::Duration};
 
+pub(crate) const NO_CRED: gss_cred_id_t = ptr::null_mut();
+
 #[derive(Debug)]
 pub struct CredInfo {
     pub name: Name,


### PR DESCRIPTION
> A GSSAPI client application uses [gss_init_sec_context](https://tools.ietf.org/html/rfc2744.html#section-5.19) to establish a security context. The initiator_cred_handle parameter determines what tickets are used to establish the connection. An application can either pass `GSS_C_NO_CREDENTIAL` to use the default client credential, […]

From: https://web.mit.edu/kerberos/krb5-1.16/doc/appdev/gssapi.html

Curl also uses `GSS_C_NO_CREDENTIAL` to implement `—negotiate` and `—proxy-negotiate`.

Which seems to make sense, when considering this comment about [`gss_acquire_cred `](https://datatracker.ietf.org/doc/html/rfc2744.html#section-5.2):

> This routine is expected to be used primarily by context acceptors,
