### PR TITLE
Fix Deref on Buf with null pointer

### DIFF
--- a/libgssapi/src/context.rs
+++ b/libgssapi/src/context.rs
@@ -572,7 +572,7 @@ impl ServerCtx {
             Ok(Some(out_tok))
         } else {
             self.state = ServerCtxState::Complete;
-            if !out_tok.is_null() {
+            if out_tok.len() > 0 {
                 Ok(Some(out_tok))
             } else {
                 Ok(None)
@@ -794,7 +794,7 @@ impl ClientCtx {
             Ok(Some(out_tok))
         } else {
             self.state = ClientCtxState::Complete;
-            if !out_tok.is_null() {
+            if out_tok.len() > 0 {
                 Ok(Some(out_tok))
             } else {
                 Ok(None)

--- a/libgssapi/src/context.rs
+++ b/libgssapi/src/context.rs
@@ -572,7 +572,7 @@ impl ServerCtx {
             Ok(Some(out_tok))
         } else {
             self.state = ServerCtxState::Complete;
-            if out_tok.len() > 0 {
+            if !out_tok.is_null() {
                 Ok(Some(out_tok))
             } else {
                 Ok(None)
@@ -794,7 +794,7 @@ impl ClientCtx {
             Ok(Some(out_tok))
         } else {
             self.state = ClientCtxState::Complete;
-            if out_tok.len() > 0 {
+            if !out_tok.is_null() {
                 Ok(Some(out_tok))
             } else {
                 Ok(None)

--- a/libgssapi/src/credential.rs
+++ b/libgssapi/src/credential.rs
@@ -1,23 +1,26 @@
 use crate::{
     error::{gss_error, Error, MajorFlags},
     name::Name,
-    oid::{Oid, OidSet, NO_OID, NO_OID_SET},
+    oid::{OidSet, NO_OID_SET},
+};
+#[cfg(feature = "s4u")]
+use crate::{
+    oid::{Oid, GSS_KRB5_GET_CRED_IMPERSONATOR, GSS_NT_HOSTBASED_SERVICE, NO_OID},
+    util::BufSet,
 };
 use libgssapi_sys::{
     gss_OID_set, gss_acquire_cred, gss_cred_id_struct, gss_cred_id_t, gss_cred_usage_t,
-    gss_inquire_cred, gss_key_value_element_desc, gss_key_value_set_desc,
-    gss_name_struct, gss_name_t, gss_release_cred, gss_store_cred_into, OM_uint32,
+    gss_inquire_cred, gss_name_struct, gss_name_t, gss_release_cred, OM_uint32,
     GSS_C_ACCEPT, GSS_C_BOTH, GSS_C_INITIATE, GSS_S_COMPLETE, _GSS_C_INDEFINITE,
 };
 #[cfg(feature = "s4u")]
-use libgssapi_sys::{gss_acquire_cred_impersonate_name, gss_inquire_cred_by_oid};
-#[cfg(feature = "s4u")]
-use crate::{oid::{GSS_NT_HOSTBASED_SERVICE, GSS_KRB5_GET_CRED_IMPERSONATOR}, util::BufSet};
-use std::{
-    ffi::{CStr, CString},
-    fmt, ptr,
-    time::Duration,
+use libgssapi_sys::{
+    gss_acquire_cred_impersonate_name, gss_inquire_cred_by_oid,
+    gss_key_value_element_desc, gss_key_value_set_desc, gss_store_cred_into,
 };
+#[cfg(feature = "s4u")]
+use std::ffi::{CStr, CString};
+use std::{fmt, ptr, time::Duration};
 
 pub(crate) const NO_CRED: gss_cred_id_t = ptr::null_mut();
 
@@ -184,6 +187,7 @@ impl Cred {
         }
     }
 
+    #[cfg(feature = "s4u")]
     pub fn store(
         &self,
         ccache: &str,

--- a/libgssapi/src/util.rs
+++ b/libgssapi/src/util.rs
@@ -276,6 +276,10 @@ impl Buf {
     pub fn to_bytes(self) -> GssBytes {
         GssBytes { pos: 0, buf: self }
     }
+
+    pub(crate) fn is_null(&self) -> bool {
+        self.0.value.is_null()
+    }
 }
 
 #[derive(Debug)]

--- a/libgssapi/src/util.rs
+++ b/libgssapi/src/util.rs
@@ -203,7 +203,11 @@ impl<'a> Deref for BufRef<'a> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
-        unsafe { slice::from_raw_parts(self.0.value.cast(), self.0.length as usize) }
+        if self.0.value.is_null() && self.0.length == 0 {
+            &[]
+        } else {
+            unsafe { slice::from_raw_parts(self.0.value.cast(), self.0.length as usize) }
+        }
     }
 }
 
@@ -238,7 +242,7 @@ impl Deref for Buf {
 
     fn deref(&self) -> &Self::Target {
         unsafe {
-            if self.0.value.is_null() {
+            if self.0.value.is_null() && self.0.length == 0 {
                 slice::from_raw_parts(NonNull::dangling().as_ptr(), 0)
             } else {
                 slice::from_raw_parts(self.0.value.cast(), self.0.length as usize)
@@ -250,7 +254,7 @@ impl Deref for Buf {
 impl DerefMut for Buf {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe {
-            if self.0.value.is_null() {
+            if self.0.value.is_null() && self.0.length == 0 {
                 slice::from_raw_parts_mut(NonNull::dangling().as_ptr(), 0)
             } else {
                 slice::from_raw_parts_mut(self.0.value.cast(), self.0.length as usize)


### PR DESCRIPTION
Resolves #22 

Rust 1.78 added a check in `slice::from_raw_parts` to make sure the value is not null, even if the length is 0. So the check `out_tok.len() > 0` would fail for an empty buf on this precondition. Updated Buf Deref to use a `NonNull::dangling` as recommended by `from_raw_parts` if the value is null.

Also had to move some new updates behind a feature flag because they didn't exist on my Mac
