### PR TITLE
Allow taking the delegated cred from ServerCtx

### DIFF
--- a/libgssapi/src/context.rs
+++ b/libgssapi/src/context.rs
@@ -583,6 +583,10 @@ impl ServerCtx {
     pub fn delegated_cred(&self) -> Option<&Cred> {
         self.delegated_cred.as_ref()
     }
+
+    pub fn take_delegated_cred(&mut self) -> Option<Cred> {
+        self.delegated_cred.take()
+    }
 }
 
 impl SecurityContext for ServerCtx {


### PR DESCRIPTION
`ClientCtx::new` requires an `Option<Cred>` if providing credentials explicitly to use as a client. Due to this, in order to use a delegated credential in a `ClientCtx`, application code needs to be able to take ownership of the `Cred` from the `ServerCtx` and pass it to `ClientCtx::new`, so there needs to be a method to get the owned `Cred` and not just a reference to it.

This enables use cases like: a web frontend to an LDAP, PostgreSQL or IMAP server which uses the delegated credential from the browser client, or a [constrained delegation (S4U2Proxy)](https://web.mit.edu/kerberos/krb5-latest/doc/appdev/gssapi.html#constrained-delegation-s4u) credential, to authenticate to the backend LDAP/PGSQL/IMAP server using GSSAPI.

This is complementary to the support for _storing_ delegated credentials in #21, as this works completely in-memory within one process using both `ServerCtx` and `ClientCtx`, versus storing the delegated credential in an external file.