### PR TITLE
Add missing checks before calling `slice::from_raw_parts`

### DIFF
--- a/libgssapi/src/oid.rs
+++ b/libgssapi/src/oid.rs
@@ -141,8 +141,10 @@ impl Deref for Oid {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
-        unsafe {
-            slice::from_raw_parts(self.0.elements as *const u8, self.0.length as usize)
+        if self.0.elements.is_null() && self.0.length == 0 {
+            &[]
+        } else {
+            unsafe { slice::from_raw_parts(self.0.elements.cast(), self.0.length as usize) }
         }
     }
 }

--- a/libgssapi/src/util.rs
+++ b/libgssapi/src/util.rs
@@ -117,14 +117,24 @@ mod iov {
 
         fn deref(&self) -> &Self::Target {
             let buf = self.0.buffer;
-            unsafe { slice::from_raw_parts(buf.value.cast(), buf.length as usize) }
+            if buf.value.is_null() && buf.length == 0 {
+                &[]
+            } else {
+                unsafe { slice::from_raw_parts(buf.value.cast(), buf.length as usize) }
+            }
         }
     }
 
     impl<'a> DerefMut for GssIov<'a> {
         fn deref_mut(&mut self) -> &mut Self::Target {
             let buf = self.0.buffer;
-            unsafe { slice::from_raw_parts_mut(buf.value.cast(), buf.length as usize) }
+            unsafe {
+                if buf.value.is_null() && buf.length == 0 {
+                    slice::from_raw_parts_mut(NonNull::dangling().as_ptr(), 0)
+                } else {
+                    slice::from_raw_parts_mut(buf.value.cast(), buf.length as usize)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
I experienced the same issue than #22 when using iov with libgssapi-0.7.1. Indeed, #23 did not fix all the calls to `slice::from_raw_parts`. 

This PR aims to fix the remaining calls to `slice::from_raw_parts`.

I'm not very comfortable with unsafe rust, so I mainly copy/pasted the fixes from #23. It seems to work.

Example of code that still result in a panic in libgssapi-0.7.1:

```rust
fn encrypt_payload(mut payload: Vec<u8>, server_ctx: &mut ServerCtx) -> Result<Vec<u8>> {
    let mut iovs = [
        GssIov::new_alloc(GssIovType::Header),
        GssIov::new(GssIovType::Data, &mut payload),
        GssIov::new_alloc(GssIovType::Padding),
    ];
    server_ctx.wrap_iov(true, &mut iovs)?;

    let mut encrypted_payload = Vec::with_capacity(
        std::mem::size_of::<i32>() + iovs[0].len() + iovs[1].len() + iovs[2].len(),
    );

    encrypted_payload.extend_from_slice(&i32::try_from(iovs[0].len())?.to_le_bytes());
    encrypted_payload.extend_from_slice(&iovs[0]);
    encrypted_payload.extend_from_slice(&iovs[1]);
    encrypted_payload.extend_from_slice(&iovs[2]); // <== the backtrace marks this line as responsible for the call to deref that panics
    drop(iovs);

    Ok(encrypted_payload)
}
```

The backtrace contains:
```
   5: core::slice::raw::from_raw_parts
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ub_checks.rs:73:17
   6: <libgssapi::util::iov::GssIov as core::ops::deref::Deref>::deref
             at /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libgssapi-0.7.1/src/util.rs:120:22
```