### PR TITLE
Fix calls to `ClientCtx::new` in examples and doc

### DIFF
--- a/libgssapi/examples/krb5.rs
+++ b/libgssapi/examples/krb5.rs
@@ -108,7 +108,7 @@ fn setup_client_ctx(
     )?;
     println!("acquired default client credentials: {:#?}", client_cred.info()?);
     Ok(ClientCtx::new(
-        client_cred, service_name, CtxFlags::GSS_C_MUTUAL_FLAG, Some(&GSS_MECH_KRB5)
+        Some(client_cred), service_name, CtxFlags::GSS_C_MUTUAL_FLAG, Some(&GSS_MECH_KRB5)
     ))
 }
 

--- a/libgssapi/examples/krb5_iov.rs
+++ b/libgssapi/examples/krb5_iov.rs
@@ -40,7 +40,7 @@ fn setup_client_ctx(
         client_cred.info()?
     );
     Ok(ClientCtx::new(
-        client_cred,
+        Some(client_cred),
         service_name,
         CtxFlags::GSS_C_MUTUAL_FLAG,
         Some(&GSS_MECH_KRB5),

--- a/libgssapi/src/lib.rs
+++ b/libgssapi/src/lib.rs
@@ -54,7 +54,7 @@
 //!         None, None, CredUsage::Initiate, Some(&desired_mechs)
 //!     )?;
 //!     Ok(ClientCtx::new(
-//!         client_cred, service_name, CtxFlags::GSS_C_MUTUAL_FLAG, Some(&GSS_MECH_KRB5)
+//!         Some(client_cred), service_name, CtxFlags::GSS_C_MUTUAL_FLAG, Some(&GSS_MECH_KRB5)
 //!     ))
 //! }
 //! 


### PR DESCRIPTION
I wanted to check that `cargo build` and `cargo test` were still working with #25, so I tried and...

```
error[E0308]: mismatched types
   --> examples/krb5.rs:111:9
    |
110 |     Ok(ClientCtx::new(
    |        -------------- arguments to this function are incorrect
111 |         client_cred, service_name, CtxFlags::GSS_C_MUTUAL_FLAG, Some(&GSS_MECH_KRB5)
    |         ^^^^^^^^^^^ expected `Option<Cred>`, found `Cred`
    |
    = note: expected enum `Option<Cred>`
             found struct `Cred`
note: associated function defined here
   --> /home/vincent/misc/libgssapi/libgssapi/src/context.rs:696:12
    |
696 |     pub fn new(
    |            ^^^
help: try wrapping the expression in `Some`
    |
111 |         Some(client_cred), service_name, CtxFlags::GSS_C_MUTUAL_FLAG, Some(&GSS_MECH_KRB5)
    |         +++++           +

error[E0308]: mismatched types
   --> examples/krb5_iov.rs:43:9
    |
42  |     Ok(ClientCtx::new(
    |        -------------- arguments to this function are incorrect
43  |         client_cred,
    |         ^^^^^^^^^^^ expected `Option<Cred>`, found `Cred`
    |
    = note: expected enum `Option<Cred>`
             found struct `Cred`
note: associated function defined here
   --> /home/vincent/misc/libgssapi/libgssapi/src/context.rs:696:12
    |
696 |     pub fn new(
    |            ^^^
help: try wrapping the expression in `Some`
    |
43  |         Some(client_cred),
    |         +++++           +

For more information about this error, try `rustc --explain E0308`.
```

So I fixed the calls to `ClientCtx::new` in examples and doc.