### PR TITLE
Add function to acquire credentials using password

### DIFF
--- a/libgssapi/examples/krb5.rs
+++ b/libgssapi/examples/krb5.rs
@@ -96,7 +96,7 @@ fn setup_server_ctx(
         Some(&cname), None, CredUsage::Accept, Some(desired_mechs)
     )?;
     println!("acquired server credentials: {:#?}", server_cred.info()?);
-    Ok((ServerCtx::new(server_cred), cname))
+    Ok((ServerCtx::new(Some(server_cred)), cname))
 }
 
 fn setup_client_ctx(

--- a/libgssapi/examples/krb5_auth.rs
+++ b/libgssapi/examples/krb5_auth.rs
@@ -1,0 +1,18 @@
+use libgssapi::credential::{Cred, CredUsage};
+use libgssapi::name::Name;
+use libgssapi::oid::{OidSet, GSS_MECH_KRB5, GSS_NT_KRB5_PRINCIPAL};
+
+fn main() {
+    let desired_mechs = {
+        let mut s = OidSet::new().expect("can't create OIDSet");
+        s.add(&GSS_MECH_KRB5).expect("can't add GSS_MECH_KRB5");
+        s
+    };
+
+    let name = Name::new("user@EXAMPLE.ORG".as_ref(), Some(&GSS_NT_KRB5_PRINCIPAL)).expect("can't create name");
+    let cred = Cred::pass_acquire(
+        Some(&name), "SuperSecret", None, CredUsage::Initiate, Some(&desired_mechs)
+    ).expect("can't create credential");
+
+    println!("cred: {:?}", cred);
+}


### PR DESCRIPTION
Simply mirrors the `acquire()` function but for `gss_acquire_cred_with_password` instead of `gss_acquire_cred`, allowing the user to authenticate and get a new credential from the KDC.

Noticed that rustfmt also made a bunch of whitespace changes, tell me if I need to revert that.