### PR TITLE
Fix examples for current credential API

### DIFF
--- a/libgssapi/examples/krb5_auth.rs
+++ b/libgssapi/examples/krb5_auth.rs
@@ -10,7 +10,7 @@ fn main() {
     };
 
     let name = Name::new("user@EXAMPLE.ORG".as_ref(), Some(&GSS_NT_KRB5_PRINCIPAL)).expect("can't create name");
-    let cred = Cred::pass_acquire(
+    let cred = Cred::acquire_with_password(
         Some(&name), "SuperSecret", None, CredUsage::Initiate, Some(&desired_mechs)
     ).expect("can't create credential");
 

--- a/libgssapi/examples/krb5_iov.rs
+++ b/libgssapi/examples/krb5_iov.rs
@@ -26,7 +26,7 @@ fn setup_server_ctx(
     let server_cred =
         Cred::acquire(Some(&cname), None, CredUsage::Accept, Some(desired_mechs))?;
     println!("acquired server credentials: {:#?}", server_cred.info()?);
-    Ok((ServerCtx::new(server_cred), cname))
+    Ok((ServerCtx::new(Some(server_cred)), cname))
 }
 
 fn setup_client_ctx(


### PR DESCRIPTION
krb5_auth used the renamed pass_acquire method, now acquire_with_password, and krb5_iov passed a bare Cred where ServerCtx::new now takes an Option.